### PR TITLE
add new bench command for add new user

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -496,6 +496,28 @@ def add_system_manager(context, email, first_name, last_name, send_welcome_email
 		raise SiteNotSpecifiedError
 
 
+@click.command("add-new-user")
+@click.argument("email")
+@click.option("--first-name")
+@click.option("--last-name")
+@click.option("--password")
+@click.option("--add-role", multiple=True)
+@click.option("--send-welcome-email", default=False, is_flag=True)
+@pass_context
+def add_new_user_for_sites(context, email, first_name, last_name, send_welcome_email, password, add_role):
+    "Add a new user to a site"
+    import frappe.utils.user
+    for site in context.sites:
+        frappe.connect(site=site)
+        try:
+            add_new_user(email, first_name, last_name, send_welcome_email, password, add_role)
+            frappe.db.commit()
+        finally:
+            frappe.destroy()
+    if not context.sites:
+        raise SiteNotSpecifiedError
+
+
 @click.command("disable-user")
 @click.argument("email")
 @pass_context
@@ -1274,9 +1296,52 @@ def handle_data(data: dict, format="json"):
 		data = [["DocType", "Fields"]] + [[table, ", ".join(columns)] for table, columns in data.items()]
 		render_table(data)
 
+def add_new_user(
+    email, first_name=None, last_name=None, send_welcome_email=False, password=None,role=None):
+    # add user
+    user = frappe.new_doc("User")
+    user.update(
+        {
+            "name": email,
+            "email": email,
+            "enabled": 1,
+            "first_name": first_name or email,
+            "last_name": last_name,
+            "user_type": "System User",
+            "send_welcome_email": 1 if send_welcome_email else 0,
+        }
+    )
+    user.insert()
+    user.add_roles(*role)
+    if password:
+        from frappe.utils.password import update_password
+        update_password(user=user.name, pwd=password)
+
+
+@click.command("list-roles")
+@pass_context
+def get_roles(context):
+    "get site available roles for users"
+    import frappe.utils.user
+    for site in context.sites:
+        frappe.connect(site=site)
+        site_title = click.style(f"{site}", fg="green")
+        print(site_title)
+        try:
+          role = frappe.get_list("Role")
+          for i in role:
+            if i.name not in ['All','Guest','Administrator']:
+              print(i.name)		  
+          print("\n")
+        finally:
+            frappe.destroy()
+    if not context.sites:
+        raise SiteNotSpecifiedError
 
 commands = [
 	add_system_manager,
+	add_new_user_for_sites,
+	get_roles,
 	backup,
 	drop_site,
 	install_app,


### PR DESCRIPTION
New Feature:
'new bench commands for adding new User with specific roles and git list roles for sites'
like=>
- bench --site site1.localhost add-new-user --first-name test1 --last-name test1 --password 123 --send-welcome-email test@gmail.com --add-role 'Accounts User' --add-role 'Sales User'
- one site=> (bench --site site1.localhost lsit-roles) or all sites=> (bench --site all list-roles)
- ![12dfb878-d0ce-4704-8658-0c1533dd75b4](https://user-images.githubusercontent.com/29329105/183830808-cda69e96-826a-433d-8c2f-e16c1874f06c.jpeg)